### PR TITLE
Update HF_TOKEN detection and model download

### DIFF
--- a/create_config.py
+++ b/create_config.py
@@ -9,106 +9,7 @@ import shutil
 import argparse
 import json
 from typing import Optional
-import requests
-from safetensors import safe_open
-import subprocess
-
-def check_hf_model_files_existences(model_name, hf_token):
-    files_to_check = [
-        "model.safetensors",
-        "model.safetensors.index.json"
-    ]
-    
-    # Prepare headers with authentication token
-    headers = {}
-    if hf_token: headers["Authorization"] = f"Bearer {hf_token}"
-    
-    index = 0
-    found_files = []
-    for file in files_to_check:
-        url = f'https://huggingface.co/{model_name}/resolve/main/{file}'
-        try:
-            # Use GET request with stream=True and authentication headers
-            response = requests.get(url, stream=True, headers=headers)
-            if response.status_code == 200:
-                found_files.append(file)
-                print(f"✅ Found {file}")
-                response.close()
-            elif response.status_code == 401:
-                print(f"❌ Authentication required for {file} (Status: {response.status_code})")
-            elif response.status_code == 403:
-                print(f"❌ Access denied for {file} (Status: {response.status_code})")
-            else:
-                print(f"❌ Not found {file} (Status: {response.status_code})")
-        except Exception as e:
-            print(f"❌ Error checking {file}: {str(e)}")
-    
-    return found_files
-
-def download_hf_model_files(files_to_download, model_name, hf_token, save_dir):        
-    downloaded_files = []
-
-    save_dir_path = f"{save_dir}/{model_name}"
-
-    for file in files_to_download:
-        if os.path.exists(os.path.join(save_dir_path, file)):
-            print(f"✅ {file} already exists")
-            downloaded_files.append(file)
-            
-            # If it's index.json, read it to get shards
-            if file.endswith('.json'):
-                with open(os.path.join(save_dir_path, file), 'r') as f:
-                    index_data = json.load(f)
-                    shards = set(index_data['weight_map'].values())
-                    print(f"Found {len(shards)} shards in index")
-                    files_to_download.extend(shards)
-            continue
-
-        model_cmd = f"huggingface-cli download {model_name} {file} --local-dir {save_dir_path} --token {hf_token}"
-        print(f"Downloading {file}...")
-        env = os.environ.copy()
-        env["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
-        env["PYTHONUNBUFFERED"] = "1"
-        result = subprocess.run(model_cmd, shell=True, check=False, env=env)            
-        
-        os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
-
-        if result.returncode == 0:
-            print(f"✅ {file} downloaded successfully")
-            downloaded_files.append(file)
-            
-            # Verify files based on their type
-            file_path = os.path.join(save_dir_path, file)
-            if file.endswith('.safetensors'):
-                try:
-                    with safe_open(file_path, framework="pytorch", device="cpu") as f:
-                        keys = list(f.keys())
-                        print(f"✅ Safetensors file is valid")
-                        print(f"- Number of tensors: {len(keys)}")
-                except Exception as e:
-                    print(f"❌ Error validating safetensors file: {str(e)}")
-                    continue
-            elif file.endswith('.json'):
-                try:
-                    with open(file_path, 'r') as f:
-                        index_data = json.load(f)
-                        shards = set(index_data['weight_map'].values())
-                        print(f"✅ Index JSON file is valid")
-                        print(f"- Number of weight shards: {len(shards)}")
-                        # Add shards to files_to_download
-                        files_to_download.extend(shards)
-                except Exception as e:
-                    print(f"❌ Error validating index JSON file: {str(e)}")
-                    continue
-        else:
-            error_message = result.stderr.decode('utf-8', errors='replace')
-            if "404 Client Error" in error_message or "Entry Not Found" in error_message:
-                print(f"❌ File {file} not found in repository")
-            else:
-                print(f"❌ Download failed: {error_message.strip()}")
-
-    print(f"\nSuccessfully downloaded files: {', '.join(downloaded_files)}")
-    return True
+from picotron.utils import download_model
 
 def create_single_config(
     out_dir: str,
@@ -181,20 +82,6 @@ def create_single_config(
     with open(os.path.join(run_path, "config.json"), "w") as new_config:
         json.dump(config_content, new_config, indent=4)
     del config_content
-
-def download_model(model_name, hf_token):
-    # Download HF model safetensors at the "hf_model_safetensors" directory
-    os.makedirs("hf_model_safetensors", exist_ok=True)
-
-    files_to_download = check_hf_model_files_existences(model_name, hf_token)
-    if len(files_to_download) <= 0:
-        raise FileNotFoundError("Safetensors files not found. Please check the model name and authentication token.")
-
-    is_downloaded = download_hf_model_files(files_to_download, model_name, hf_token, save_dir="hf_model_safetensors")
-    if not is_downloaded:
-        raise FileNotFoundError("Failed to download safetensors files. Please check the model name and authentication token.")
-
-    print("SafeTensors files downloaded successfully! ✅")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/create_config.py
+++ b/create_config.py
@@ -182,6 +182,20 @@ def create_single_config(
         json.dump(config_content, new_config, indent=4)
     del config_content
 
+def download_model(model_name, hf_token):
+    # Download HF model safetensors at the "hf_model_safetensors" directory
+    os.makedirs("hf_model_safetensors", exist_ok=True)
+
+    files_to_download = check_hf_model_files_existences(model_name, hf_token)
+    if len(files_to_download) <= 0:
+        raise FileNotFoundError("Safetensors files not found. Please check the model name and authentication token.")
+
+    is_downloaded = download_hf_model_files(files_to_download, model_name, hf_token, save_dir="hf_model_safetensors")
+    if not is_downloaded:
+        raise FileNotFoundError("Failed to download safetensors files. Please check the model name and authentication token.")
+
+    print("SafeTensors files downloaded successfully! ✅")
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--out_dir", type=str, help="Output directory to store the configs", default="tmp")
@@ -230,15 +244,6 @@ if __name__ == "__main__":
 
     print("Configs created successfully! ✅")
 
-    # Download HF model safetensors at the "hf_model_safetensors" directory
-    os.makedirs("hf_model_safetensors", exist_ok=True)
-
-    files_to_download = check_hf_model_files_existences(args.model_name, args.hf_token)
-    if len(files_to_download) <= 0:
-        raise FileNotFoundError("Safetensors files not found. Please check the model name and authentication token.")
-
-    is_downloaded = download_hf_model_files(files_to_download, args.model_name, args.hf_token, save_dir="hf_model_safetensors")
-    if not is_downloaded:
-        raise FileNotFoundError("Failed to download safetensors files. Please check the model name and authentication token.")
+    download_model(args.model_name, args.hf_token)
 
     print("SafeTensors files downloaded successfully! ✅")

--- a/picotron/utils.py
+++ b/picotron/utils.py
@@ -105,7 +105,6 @@ def download_model(model_name, hf_token):
     # Download HF model safetensors at the "hf_model_safetensors" directory
     os.makedirs("hf_model_safetensors", exist_ok=True)
     print("Downloading SafeTensors files...")
-    os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
     snapshot_download(model_name, repo_type="model", local_dir="hf_model_safetensors", token=hf_token, allow_patterns=["*.safetensors", "*.json"])
     # Check if the model has SafeTensors files
     if not os.path.exists("hf_model_safetensors/model.safetensors"):

--- a/picotron/utils.py
+++ b/picotron/utils.py
@@ -104,5 +104,10 @@ def average_loss_across_dp_cp_ranks(loss, device):
 def download_model(model_name, hf_token):
     # Download HF model safetensors at the "hf_model_safetensors" directory
     os.makedirs("hf_model_safetensors", exist_ok=True)
+    print("Downloading SafeTensors files...")
+    os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
     snapshot_download(model_name, repo_type="model", local_dir="hf_model_safetensors", token=hf_token, allow_patterns=["*.safetensors", "*.json"])
+    # Check if the model has SafeTensors files
+    if not os.path.exists("hf_model_safetensors/model.safetensors"):
+        raise ValueError(f"Model {model_name} does not have SafeTensors files.")
     print("SafeTensors files downloaded successfully! ✅")

--- a/picotron/utils.py
+++ b/picotron/utils.py
@@ -1,7 +1,4 @@
-import json
 import os
-import subprocess
-import requests
 import random
 import numpy as np
 import builtins
@@ -101,8 +98,13 @@ def average_loss_across_dp_cp_ranks(loss, device):
     return reduced_loss.item()
 
 def download_model(model_name, hf_token):
-    # Download HF model safetensors at the "hf_model_safetensors" directory
-    os.makedirs("hf_model_safetensors", exist_ok=True)
+    dst = os.path.join("hf_model", model_name)
+    os.makedirs(dst, exist_ok=True)
+    # check if model is already downloaded
+    if os.path.exists(os.path.join(dst, "config.json")):
+        print(f"Model {model_name} already exists at {dst}")
+        return
+    # Download HF model safetensors at the "dst" directory
     huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
     print("Downloading SafeTensors files...")
     huggingface_hub.snapshot_download(model_name, repo_type="model", local_dir="hf_model_safetensors", token=hf_token,

--- a/picotron/utils.py
+++ b/picotron/utils.py
@@ -7,8 +7,7 @@ import numpy as np
 import builtins
 import fcntl
 
-from huggingface_hub import hf_hub_download, snapshot_download
-from safetensors import safe_open
+import huggingface_hub
 
 import picotron.process_group_manager as pgm
 import torch, torch.distributed as dist
@@ -104,8 +103,10 @@ def average_loss_across_dp_cp_ranks(loss, device):
 def download_model(model_name, hf_token):
     # Download HF model safetensors at the "hf_model_safetensors" directory
     os.makedirs("hf_model_safetensors", exist_ok=True)
+    huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
     print("Downloading SafeTensors files...")
-    snapshot_download(model_name, repo_type="model", local_dir="hf_model_safetensors", token=hf_token, allow_patterns=["*.safetensors", "*.json"])
+    huggingface_hub.snapshot_download(model_name, repo_type="model", local_dir="hf_model_safetensors", token=hf_token,
+                                      allow_patterns=["*.safetensors", "*.json"])
     # Check if the model has SafeTensors files
     if not os.path.exists("hf_model_safetensors/model.safetensors"):
         raise ValueError(f"Model {model_name} does not have SafeTensors files.")

--- a/picotron/utils.py
+++ b/picotron/utils.py
@@ -7,6 +7,7 @@ import numpy as np
 import builtins
 import fcntl
 
+from huggingface_hub import hf_hub_download, snapshot_download
 from safetensors import safe_open
 
 import picotron.process_group_manager as pgm
@@ -100,113 +101,8 @@ def average_loss_across_dp_cp_ranks(loss, device):
         reduced_loss /= pgm.process_group_manager.cp_dp_world_size
     return reduced_loss.item()
 
-def check_hf_model_files_existences(model_name, hf_token):
-    files_to_check = [
-        "model.safetensors",
-        "model.safetensors.index.json"
-    ]
-
-    # Prepare headers with authentication token
-    headers = {}
-    if hf_token: headers["Authorization"] = f"Bearer {hf_token}"
-
-    index = 0
-    found_files = []
-    for file in files_to_check:
-        url = f'https://huggingface.co/{model_name}/resolve/main/{file}'
-        try:
-            # Use GET request with stream=True and authentication headers
-            response = requests.get(url, stream=True, headers=headers)
-            if response.status_code == 200:
-                found_files.append(file)
-                print(f"✅ Found {file}")
-                response.close()
-            elif response.status_code == 401:
-                print(f"❌ Authentication required for {file} (Status: {response.status_code})")
-            elif response.status_code == 403:
-                print(f"❌ Access denied for {file} (Status: {response.status_code})")
-            else:
-                print(f"❌ Not found {file} (Status: {response.status_code})")
-        except Exception as e:
-            print(f"❌ Error checking {file}: {str(e)}")
-
-    return found_files
-
-def download_hf_model_files(files_to_download, model_name, hf_token, save_dir):
-    downloaded_files = []
-
-    save_dir_path = f"{save_dir}/{model_name}"
-
-    for file in files_to_download:
-        if os.path.exists(os.path.join(save_dir_path, file)):
-            print(f"✅ {file} already exists")
-            downloaded_files.append(file)
-
-            # If it's index.json, read it to get shards
-            if file.endswith('.json'):
-                with open(os.path.join(save_dir_path, file), 'r') as f:
-                    index_data = json.load(f)
-                    shards = set(index_data['weight_map'].values())
-                    print(f"Found {len(shards)} shards in index")
-                    files_to_download.extend(shards)
-            continue
-
-        model_cmd = f"huggingface-cli download {model_name} {file} --local-dir {save_dir_path} --token {hf_token}"
-        print(f"Downloading {file}...")
-        env = os.environ.copy()
-        env["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
-        env["PYTHONUNBUFFERED"] = "1"
-        result = subprocess.run(model_cmd, shell=True, check=False, env=env)
-
-        os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
-
-        if result.returncode == 0:
-            print(f"✅ {file} downloaded successfully")
-            downloaded_files.append(file)
-
-            # Verify files based on their type
-            file_path = os.path.join(save_dir_path, file)
-            if file.endswith('.safetensors'):
-                try:
-                    with safe_open(file_path, framework="pytorch", device="cpu") as f:
-                        keys = list(f.keys())
-                        print(f"✅ Safetensors file is valid")
-                        print(f"- Number of tensors: {len(keys)}")
-                except Exception as e:
-                    print(f"❌ Error validating safetensors file: {str(e)}")
-                    continue
-            elif file.endswith('.json'):
-                try:
-                    with open(file_path, 'r') as f:
-                        index_data = json.load(f)
-                        shards = set(index_data['weight_map'].values())
-                        print(f"✅ Index JSON file is valid")
-                        print(f"- Number of weight shards: {len(shards)}")
-                        # Add shards to files_to_download
-                        files_to_download.extend(shards)
-                except Exception as e:
-                    print(f"❌ Error validating index JSON file: {str(e)}")
-                    continue
-        else:
-            error_message = result.stderr.decode('utf-8', errors='replace')
-            if "404 Client Error" in error_message or "Entry Not Found" in error_message:
-                print(f"❌ File {file} not found in repository")
-            else:
-                print(f"❌ Download failed: {error_message.strip()}")
-
-    print(f"\nSuccessfully downloaded files: {', '.join(downloaded_files)}")
-    return True
-
 def download_model(model_name, hf_token):
     # Download HF model safetensors at the "hf_model_safetensors" directory
     os.makedirs("hf_model_safetensors", exist_ok=True)
-
-    files_to_download = check_hf_model_files_existences(model_name, hf_token)
-    if len(files_to_download) <= 0:
-        raise FileNotFoundError("Safetensors files not found. Please check the model name and authentication token.")
-
-    is_downloaded = download_hf_model_files(files_to_download, model_name, hf_token, save_dir="hf_model_safetensors")
-    if not is_downloaded:
-        raise FileNotFoundError("Failed to download safetensors files. Please check the model name and authentication token.")
-
+    snapshot_download(model_name, repo_type="model", local_dir="hf_model_safetensors", token=hf_token, allow_patterns=["*.safetensors", "*.json"])
     print("SafeTensors files downloaded successfully! ✅")

--- a/picotron/utils.py
+++ b/picotron/utils.py
@@ -1,8 +1,14 @@
-import torch
+import json
+import os
+import subprocess
+import requests
 import random
 import numpy as np
 import builtins
 import fcntl
+
+from safetensors import safe_open
+
 import picotron.process_group_manager as pgm
 import torch, torch.distributed as dist
 
@@ -93,3 +99,114 @@ def average_loss_across_dp_cp_ranks(loss, device):
         dist.all_reduce(reduced_loss, op=dist.ReduceOp.SUM, group=pgm.process_group_manager.cp_dp_group)
         reduced_loss /= pgm.process_group_manager.cp_dp_world_size
     return reduced_loss.item()
+
+def check_hf_model_files_existences(model_name, hf_token):
+    files_to_check = [
+        "model.safetensors",
+        "model.safetensors.index.json"
+    ]
+
+    # Prepare headers with authentication token
+    headers = {}
+    if hf_token: headers["Authorization"] = f"Bearer {hf_token}"
+
+    index = 0
+    found_files = []
+    for file in files_to_check:
+        url = f'https://huggingface.co/{model_name}/resolve/main/{file}'
+        try:
+            # Use GET request with stream=True and authentication headers
+            response = requests.get(url, stream=True, headers=headers)
+            if response.status_code == 200:
+                found_files.append(file)
+                print(f"✅ Found {file}")
+                response.close()
+            elif response.status_code == 401:
+                print(f"❌ Authentication required for {file} (Status: {response.status_code})")
+            elif response.status_code == 403:
+                print(f"❌ Access denied for {file} (Status: {response.status_code})")
+            else:
+                print(f"❌ Not found {file} (Status: {response.status_code})")
+        except Exception as e:
+            print(f"❌ Error checking {file}: {str(e)}")
+
+    return found_files
+
+def download_hf_model_files(files_to_download, model_name, hf_token, save_dir):
+    downloaded_files = []
+
+    save_dir_path = f"{save_dir}/{model_name}"
+
+    for file in files_to_download:
+        if os.path.exists(os.path.join(save_dir_path, file)):
+            print(f"✅ {file} already exists")
+            downloaded_files.append(file)
+
+            # If it's index.json, read it to get shards
+            if file.endswith('.json'):
+                with open(os.path.join(save_dir_path, file), 'r') as f:
+                    index_data = json.load(f)
+                    shards = set(index_data['weight_map'].values())
+                    print(f"Found {len(shards)} shards in index")
+                    files_to_download.extend(shards)
+            continue
+
+        model_cmd = f"huggingface-cli download {model_name} {file} --local-dir {save_dir_path} --token {hf_token}"
+        print(f"Downloading {file}...")
+        env = os.environ.copy()
+        env["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+        env["PYTHONUNBUFFERED"] = "1"
+        result = subprocess.run(model_cmd, shell=True, check=False, env=env)
+
+        os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+
+        if result.returncode == 0:
+            print(f"✅ {file} downloaded successfully")
+            downloaded_files.append(file)
+
+            # Verify files based on their type
+            file_path = os.path.join(save_dir_path, file)
+            if file.endswith('.safetensors'):
+                try:
+                    with safe_open(file_path, framework="pytorch", device="cpu") as f:
+                        keys = list(f.keys())
+                        print(f"✅ Safetensors file is valid")
+                        print(f"- Number of tensors: {len(keys)}")
+                except Exception as e:
+                    print(f"❌ Error validating safetensors file: {str(e)}")
+                    continue
+            elif file.endswith('.json'):
+                try:
+                    with open(file_path, 'r') as f:
+                        index_data = json.load(f)
+                        shards = set(index_data['weight_map'].values())
+                        print(f"✅ Index JSON file is valid")
+                        print(f"- Number of weight shards: {len(shards)}")
+                        # Add shards to files_to_download
+                        files_to_download.extend(shards)
+                except Exception as e:
+                    print(f"❌ Error validating index JSON file: {str(e)}")
+                    continue
+        else:
+            error_message = result.stderr.decode('utf-8', errors='replace')
+            if "404 Client Error" in error_message or "Entry Not Found" in error_message:
+                print(f"❌ File {file} not found in repository")
+            else:
+                print(f"❌ Download failed: {error_message.strip()}")
+
+    print(f"\nSuccessfully downloaded files: {', '.join(downloaded_files)}")
+    return True
+
+def download_model(model_name, hf_token):
+    # Download HF model safetensors at the "hf_model_safetensors" directory
+    os.makedirs("hf_model_safetensors", exist_ok=True)
+
+    files_to_download = check_hf_model_files_existences(model_name, hf_token)
+    if len(files_to_download) <= 0:
+        raise FileNotFoundError("Safetensors files not found. Please check the model name and authentication token.")
+
+    is_downloaded = download_hf_model_files(files_to_download, model_name, hf_token, save_dir="hf_model_safetensors")
+    if not is_downloaded:
+        raise FileNotFoundError("Failed to download safetensors files. Please check the model name and authentication token.")
+
+    print("SafeTensors files downloaded successfully! ✅")

--- a/train.py
+++ b/train.py
@@ -23,7 +23,7 @@ from picotron.process_group_manager import setup_process_group_manager
 from picotron.pipeline_parallel.pipeline_parallel import train_step_pipeline_1f1b, train_step_pipeline_afab, PipelineParallel
 from picotron.data_parallel.data_parallel import DataParallelBucket
 from picotron.model import Llama
-from .create_config import download_model
+from picotron.utils import download_model
 import wandb
 
 def train_step(model, data_loader, device):

--- a/train.py
+++ b/train.py
@@ -66,11 +66,13 @@ if __name__ == "__main__":
     os.environ["TOKENIZERS_PARALLELISM"] = config["environment"]["TOKENIZERS_PARALLELISM"]
     os.environ["FLASH_ATTEN"] = config["environment"]["FLASH_ATTEN"]
     os.environ["DEVICE"] = "cpu" if config["distributed"]["use_cpu"] else "cuda"
-    if config["environment"].get("HF_TOKEN") is None and "HF_TOKEN" not in os.environ: raise ValueError("HF_TOKEN is neither set in the config file nor in the environment")
-    if config["environment"].get("HF_TOKEN") and "HF_TOKEN" not in os.environ:
-        os.environ["HF_TOKEN"] = config["environment"]["HF_TOKEN"]
+    if config["environment"].get("HF_TOKEN") is None:
+        if "HF_TOKEN" not in os.environ: raise ValueError("HF_TOKEN is neither set in the config file nor in the environment")
     else:
-        print("Warning: HF_TOKEN is set in the environment and the config file. Using the environment variable.")
+        if "HF_TOKEN" not in os.environ:
+            os.environ["HF_TOKEN"] = config["environment"]["HF_TOKEN"]
+        else:
+            print("Warning: HF_TOKEN is set in the environment and the config file. Using the environment variable.")
     dtype = torch.bfloat16 if torch.cuda.is_available() and torch.cuda.is_bf16_supported() and not config["distributed"]["use_cpu"] else torch.float32
     assert (dtype == torch.bfloat16 and os.getenv("FLASH_ATTEN") == "1") or os.getenv("FLASH_ATTEN") != "1", "Kernel operations requires dtype=torch.bfloat16"
     

--- a/train.py
+++ b/train.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
         if pgm.process_group_manager.pp_world_size > 1:
             model = PipelineParallel(model, model_config)
 
-    model = init_model_with_materialized_weights(model, model_config, save_dir=f"./hf_model_safetensors/{model_config._name_or_path}")
+    model = init_model_with_materialized_weights(model, model_config, save_dir=f"./hf_model_safetensors/")
 
     #TODO: load existing checkpoint here to continue pre-training
 

--- a/train.py
+++ b/train.py
@@ -66,11 +66,11 @@ if __name__ == "__main__":
     os.environ["TOKENIZERS_PARALLELISM"] = config["environment"]["TOKENIZERS_PARALLELISM"]
     os.environ["FLASH_ATTEN"] = config["environment"]["FLASH_ATTEN"]
     os.environ["DEVICE"] = "cpu" if config["distributed"]["use_cpu"] else "cuda"
-    # retrieve the HF_TOKEN from the config file or the environment
-    hf_token = config["environment"].get("HF_TOKEN", os.getenv("HF_TOKEN"))
-    if not hf_token:
-        raise ValueError("HF_TOKEN is neither set in the config file nor in the environment")
-    os.environ["HF_TOKEN"] = hf_token
+    if config["environment"].get("HF_TOKEN") is None and "HF_TOKEN" not in os.environ: raise ValueError("HF_TOKEN is neither set in the config file nor in the environment")
+    if config["environment"].get("HF_TOKEN") and "HF_TOKEN" not in os.environ:
+        os.environ["HF_TOKEN"] = config["environment"]["HF_TOKEN"]
+    else:
+        print("Warning: HF_TOKEN is set in the environment and the config file. Using the environment variable.")
     dtype = torch.bfloat16 if torch.cuda.is_available() and torch.cuda.is_bf16_supported() and not config["distributed"]["use_cpu"] else torch.float32
     assert (dtype == torch.bfloat16 and os.getenv("FLASH_ATTEN") == "1") or os.getenv("FLASH_ATTEN") != "1", "Kernel operations requires dtype=torch.bfloat16"
     

--- a/train.py
+++ b/train.py
@@ -4,7 +4,6 @@ CUDA_DEVICE_MAX_CONNECTIONS=1 debugpy-run -p 5678 -m torch.distributed.run -- --
 """
 import os
 import inspect
-import datetime
 import json
 import time
 import datetime
@@ -24,6 +23,7 @@ from picotron.process_group_manager import setup_process_group_manager
 from picotron.pipeline_parallel.pipeline_parallel import train_step_pipeline_1f1b, train_step_pipeline_afab, PipelineParallel
 from picotron.data_parallel.data_parallel import DataParallelBucket
 from picotron.model import Llama
+from .create_config import download_model
 import wandb
 
 def train_step(model, data_loader, device):
@@ -75,7 +75,9 @@ if __name__ == "__main__":
             print("Warning: HF_TOKEN is set in the environment and the config file. Using the environment variable.")
     dtype = torch.bfloat16 if torch.cuda.is_available() and torch.cuda.is_bf16_supported() and not config["distributed"]["use_cpu"] else torch.float32
     assert (dtype == torch.bfloat16 and os.getenv("FLASH_ATTEN") == "1") or os.getenv("FLASH_ATTEN") != "1", "Kernel operations requires dtype=torch.bfloat16"
-    
+
+    download_model(config["model"]["name"], os.environ["HF_TOKEN"])
+
     local_rank = int(os.environ["LOCAL_RANK"])
     global_rank = int(os.environ["RANK"])
     world_size = int(os.environ["WORLD_SIZE"])

--- a/train.py
+++ b/train.py
@@ -66,8 +66,11 @@ if __name__ == "__main__":
     os.environ["TOKENIZERS_PARALLELISM"] = config["environment"]["TOKENIZERS_PARALLELISM"]
     os.environ["FLASH_ATTEN"] = config["environment"]["FLASH_ATTEN"]
     os.environ["DEVICE"] = "cpu" if config["distributed"]["use_cpu"] else "cuda"
-    if config["environment"]["HF_TOKEN"] is None: raise ValueError("HF_TOKEN is not set in the config file")
-    os.environ["HF_TOKEN"] = config["environment"]["HF_TOKEN"]
+    # retrieve the HF_TOKEN from the config file or the environment
+    hf_token = config["environment"].get("HF_TOKEN", os.getenv("HF_TOKEN"))
+    if not hf_token:
+        raise ValueError("HF_TOKEN is neither set in the config file nor in the environment")
+    os.environ["HF_TOKEN"] = hf_token
     dtype = torch.bfloat16 if torch.cuda.is_available() and torch.cuda.is_bf16_supported() and not config["distributed"]["use_cpu"] else torch.float32
     assert (dtype == torch.bfloat16 and os.getenv("FLASH_ATTEN") == "1") or os.getenv("FLASH_ATTEN") != "1", "Kernel operations requires dtype=torch.bfloat16"
     


### PR DESCRIPTION
# What does this PR do?

1. For best security practices HF_TOKEN should be first pulled out from the environment and maybe then from configuration file, this PR ensures it.
2. Model download is handled manually. This PR relies on `huggingface_hub` lib to download the model using `hf_transfer` simplifying the current process.
