### PR TITLE
handle case when model has multiple .safetensors

### DIFF
--- a/picotron/utils.py
+++ b/picotron/utils.py
@@ -3,6 +3,7 @@ import random
 import numpy as np
 import builtins
 import fcntl
+import glob
 
 import huggingface_hub
 
@@ -110,6 +111,6 @@ def download_model(model_name, hf_token):
     huggingface_hub.snapshot_download(model_name, repo_type="model", local_dir="hf_model_safetensors", token=hf_token,
                                       allow_patterns=["*.safetensors", "*.json"])
     # Check if the model has SafeTensors files
-    if not os.path.exists("hf_model_safetensors/model.safetensors"):
+    if not glob.glob("hf_model_safetensors/*.safetensors"):
         raise ValueError(f"Model {model_name} does not have SafeTensors files.")
     print("SafeTensors files downloaded successfully! ✅")


### PR DESCRIPTION
I was getting 

```
Traceback (most recent call last):
  File "/fsx/jason/picotron/create_config.py", line 134, in <module>
    download_model(args.model_name, args.hf_token)
  File "/fsx/jason/picotron/picotron/utils.py", line 114, in download_model
    raise ValueError(f"Model {model_name} does not have SafeTensors files.")
ValueError: Model HuggingFaceTB/SmolLM-1.7B does not have SafeTensors files.
```

because the SmolLM safetensors was sharded