### PR TITLE
opt ce loss

### DIFF
--- a/picotron/pipeline_parallel/pipeline_parallel.py
+++ b/picotron/pipeline_parallel/pipeline_parallel.py
@@ -104,7 +104,7 @@ def train_step_pipeline_afab(model, data_loader, tensor_shapes, device, dtype):
         
         # calculate loss on the last stage
         if pgm.process_group_manager.pp_is_last_stage:
-            output_tensor = F.cross_entropy(output_tensor.transpose(1, 2), batch["target_ids"].to(device), reduction='mean')
+            output_tensor = F.cross_entropy(output_tensor.flatten(0, 1), batch["target_ids"].to(device).flatten(), reduction='mean')
             logging_loss += output_tensor.item() / data_loader.grad_acc_steps
 
         # Save input/output activations to reconstruct computation graph during backward pass
@@ -157,7 +157,7 @@ def train_step_pipeline_1f1b(model, data_loader, tensor_shapes, device, dtype):
         
         # calculate loss on the last stage
         if pgm.process_group_manager.pp_is_last_stage:
-            output_tensor = F.cross_entropy(output_tensor.transpose(1, 2), batch["target_ids"].to(device), reduction='mean')
+            output_tensor = F.cross_entropy(output_tensor.flatten(0, 1), batch["target_ids"].to(device).flatten(), reduction='mean')
             nonlocal logging_loss
             logging_loss += output_tensor.item() / data_loader.grad_acc_steps
         return output_tensor


### PR DESCRIPTION
As shown in the following code, the current cross entropy loss computation is very slow. The results of the code are 1.2s and 0.02s respectively.

```python
import time
import torch
import torch.nn.functional as F

def bench(func):
    for _ in range(3):
        func()
    torch.cuda.synchronize()
    t = time.time()
    for _ in range(10):
        func()
    torch.cuda.synchronize()
    return time.time() - t

batch_size = 4
seq_len = 2048
vocab_size = 100 * 1024
output_tensor = torch.randn(batch_size, seq_len, vocab_size, dtype=torch.bfloat16, device="cuda")
target_ids = torch.randint(0, vocab_size, (batch_size, seq_len), dtype=torch.long, device="cuda")

print(bench(lambda: F.cross_entropy(output_tensor.transpose(1, 2), target_ids, reduce='mean')))

print(bench(lambda: F.cross_entropy(output_tensor.flatten(0, 1), target_ids.flatten(), reduce='mean')))
```

In this PR, I replace the cross entropy loss computation. In my experiment of `Qwen2.5-0.5B`, MFU (Model FLOPs Utilization) of dp4pp2tp1 increased from 5% to 40%. 